### PR TITLE
[EH][DDCE-1860] Added x-correlation-id to outbound requests

### DIFF
--- a/app/connectors/FileUploadConnector.scala
+++ b/app/connectors/FileUploadConnector.scala
@@ -102,7 +102,7 @@ class FileUploadConnector @Inject()(appConfig: MicroserviceAppConfig,
         hc.gaUserId.map(HeaderNames.googleAnalyticUserId -> _),
         hc.deviceID.map(HeaderNames.deviceID -> _),
         hc.akamaiReputation.map(HeaderNames.akamaiReputation -> _.value)
-      ).flatten ++ Seq("CSRF-token" -> "nocheck")
+      ).flatten ++ Seq("CSRF-token" -> "nocheck") ++ hc.extraHeaders
 
     }
 

--- a/app/controllers/SubmissionController.scala
+++ b/app/controllers/SubmissionController.scala
@@ -28,17 +28,20 @@ import services.SubmissionService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.{ExecutionContext, Future}
+import uk.gov.hmrc.http.HeaderCarrier
+import utils.CorrelationIdHelper
 
 @Singleton
 class SubmissionController @Inject()( val submissionService: SubmissionService,
                                       auditService: AuditService,
                                       cc: ControllerComponents
-                                    ) extends BackendController(cc) with Logging {
+                                    ) extends BackendController(cc) with Logging with CorrelationIdHelper {
 
   implicit val ec: ExecutionContext = cc.executionContext
 
   def submit() : Action[Submission] = Action.async(parse.json[Submission]) {
     implicit request =>
+      implicit val hc: HeaderCarrier = getOrCreateCorrelationID(request)
       auditService.sendEvent(
         CTUTRSubmission(
           request.body.companyDetails.companyReferenceNumber,

--- a/app/services/PdfService.scala
+++ b/app/services/PdfService.scala
@@ -20,10 +20,11 @@ import javax.inject.{Inject, Singleton}
 import connectors.PdfConnector
 
 import scala.concurrent.Future
+import uk.gov.hmrc.http.HeaderCarrier
 
 @Singleton
 class PdfService @Inject()( val pdfConnector: PdfConnector) {
 
-  def generatePdf(html: String): Future[Array[Byte]] = pdfConnector.generatePdf(html)
+  def generatePdf(html: String)(implicit hc: HeaderCarrier): Future[Array[Byte]] = pdfConnector.generatePdf(html)
 
 }

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -99,7 +99,7 @@ class SubmissionService @Inject()(
     robotXml(metadata, viewModel).toString().getBytes
   }
 
-  def createPdf(submission: Submission): Future[Array[Byte]] = {
+  def createPdf(submission: Submission)(implicit hc: HeaderCarrier): Future[Array[Byte]] = {
     val viewModel = SubmissionViewModel.apply(submission)
     val pdfTemplate = CTUTRScheme(viewModel).toString
     pdfService.generatePdf(pdfTemplate)

--- a/app/utils/CorrelationIdHelper.scala
+++ b/app/utils/CorrelationIdHelper.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import java.util.UUID
+import play.api.mvc.Request
+
+trait CorrelationIdHelper {
+  protected val HEADER_X_CORRELATION_ID: String = "X-Correlation-Id"
+  protected def getOrCreateCorrelationID(request: Request[_]): HeaderCarrier = {
+    val hcFromRequest: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
+    val hc: HeaderCarrier =
+      hcFromRequest
+        .headers(Seq(HEADER_X_CORRELATION_ID)) match {
+          case Nil =>
+            hcFromRequest
+              .withExtraHeaders((
+                HEADER_X_CORRELATION_ID,
+                UUID
+                  .randomUUID()
+                  .toString()
+              ))
+          case _ =>
+            hcFromRequest
+        }
+    hc
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -11,10 +11,12 @@ lazy val appDependencies: Seq[ModuleID] = compile ++ test
 
 val scope: String = "test,it"
 val silencerVersion: String = "1.7.1"
+val bootstrapPlayVersion: String = "5.14.0"
+val scalaTestVersion: String = "3.2.9.0"
 
 val compile = Seq(
   ws,
-  "uk.gov.hmrc" %% "bootstrap-backend-play-28" % "5.10.0",
+  "uk.gov.hmrc" %% "bootstrap-backend-play-28" % bootstrapPlayVersion,
   "uk.gov.hmrc" %% "domain"                    % "6.2.0-play-28",
   "uk.gov.hmrc" %% "json-encryption"           % "4.10.0-play-28",
   compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
@@ -22,15 +24,13 @@ val compile = Seq(
 )
 
 val test: Seq[ModuleID] = Seq(
-  "org.scalatestplus"      %% "mockito-3-4"        % "3.2.9.0"           % scope,
-  "org.scalatestplus"      %% "scalacheck-1-15"    % "3.2.9.0"           % scope,
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0"             % scope,
-  "com.typesafe.play"      %% "play-test"          % PlayVersion.current % scope,
-  "com.github.tomakehurst" % "wiremock-jre8"       % "2.30.0"            % scope,
-  "org.pegdown"            % "pegdown"             % "1.6.0"             % scope,
-  "org.jsoup"              % "jsoup"               % "1.14.1"            % scope,
-  "com.vladsch.flexmark"   % "flexmark-all"        % "0.36.8"            % scope,
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.0"    % scope
+  "uk.gov.hmrc"            %% "bootstrap-test-play-28" % bootstrapPlayVersion % scope,
+  "com.typesafe.play"      %% "play-test"              % PlayVersion.current  % scope,
+  "org.scalatestplus"      %% "mockito-3-4"            % scalaTestVersion     % scope,
+  "org.scalatestplus"      %% "scalacheck-1-15"        % scalaTestVersion     % scope,
+  "com.github.tomakehurst" % "wiremock-jre8"           % "2.30.0"             % scope,
+  "org.jsoup"              % "jsoup"                   % "1.14.3"             % scope,
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.0"         % scope
 )
 
 lazy val microservice = Project(appName, file("."))

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -26,7 +26,6 @@ play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
 
 # Define any modules used here
-play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.backend.BackendModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"

--- a/test/connectors/FileUploadConnectorSpec.scala
+++ b/test/connectors/FileUploadConnectorSpec.scala
@@ -30,6 +30,7 @@ import play.api.inject.Injector
 import play.api.libs.json.{JsArray, Json}
 import uk.gov.hmrc.http.{AkamaiReputation, Authorization, ForwardedFor, HeaderCarrier, RequestId, SessionId}
 import util.WireMockHelper
+import java.util.UUID
 
 class FileUploadConnectorSpec extends PlaySpec with WireMockHelper with ScalaFutures with ScalaCheckPropertyChecks with IntegrationPatience {
 
@@ -39,16 +40,19 @@ class FileUploadConnectorSpec extends PlaySpec with WireMockHelper with ScalaFut
 
   implicit def dontShrink[A]: Shrink[A] = Shrink.shrinkAny
 
-  implicit val hc = HeaderCarrier(authorization = Some(Authorization("")),
+  private lazy val randomCorrelationId: String = UUID.randomUUID().toString()
+  implicit val hc = HeaderCarrier(
+    authorization = Some(Authorization("")),
     forwarded = Some(ForwardedFor("")),
-      sessionId = Some(SessionId("")),
-      requestId = Some(RequestId("")),
-      trueClientIp = Some(""),
-      trueClientPort = Some(""),
-      gaToken = Some(""),
-      gaUserId = Some(""),
-      deviceID = Some(""),
-      akamaiReputation = Some(AkamaiReputation(""))
+    sessionId = Some(SessionId("")),
+    requestId = Some(RequestId("")),
+    trueClientIp = Some(""),
+    trueClientPort = Some(""),
+    gaToken = Some(""),
+    gaUserId = Some(""),
+    deviceID = Some(""),
+    akamaiReputation = Some(AkamaiReputation("")),
+    extraHeaders = Seq(("X-Correlation-Id", randomCorrelationId))
   )
 
   private lazy val connector: FileUploadConnector =

--- a/test/connectors/PdfConnectorSpec.scala
+++ b/test/connectors/PdfConnectorSpec.scala
@@ -52,6 +52,7 @@ class PdfConnectorSpec extends TestFixture
         val httpResponse = createMockResponse(200, htmlAsString)
 
         when(mockWsClient.url(eqTo(gernerateUrl))).thenReturn(mockWsRequest)
+        when(mockWsRequest.addHttpHeaders(any())).thenReturn(mockWsRequest)
         when(mockWsRequest.post(eqTo(body))(any())).thenReturn(Future.successful(httpResponse))
 
         val response = pdfConnector.generatePdf(htmlAsString)
@@ -71,6 +72,7 @@ class PdfConnectorSpec extends TestFixture
         val httpResponse = createMockResponse(400, "")
 
         when(mockWsClient.url(eqTo(gernerateUrl))).thenReturn(mockWsRequest)
+        when(mockWsRequest.addHttpHeaders(any())).thenReturn(mockWsRequest)
         when(mockWsRequest.post(eqTo(body))(any())).thenReturn(Future.successful(httpResponse))
 
         val result = pdfConnector.generatePdf(htmlAsString)

--- a/test/services/PdfServiceSpec.scala
+++ b/test/services/PdfServiceSpec.scala
@@ -36,7 +36,7 @@ class PdfServiceSpec extends TestFixture {
 
         val htmlAsString = "<html>test</html>"
 
-        when(pdfService.pdfConnector.generatePdf(any())).thenReturn(Future.successful(htmlAsString.getBytes))
+        when(pdfService.pdfConnector.generatePdf(any())(any())).thenReturn(Future.successful(htmlAsString.getBytes))
 
         val response = pdfService.generatePdf(htmlAsString)
 
@@ -52,7 +52,7 @@ class PdfServiceSpec extends TestFixture {
 
         val htmlAsString = "<html>test</html>"
 
-        when(pdfService.pdfConnector.generatePdf(any())).thenReturn(Future.failed(new HttpException("", 0)))
+        when(pdfService.pdfConnector.generatePdf(any())(any())).thenReturn(Future.failed(new HttpException("", 0)))
 
         val result = pdfService.generatePdf(htmlAsString)
 

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -49,7 +49,7 @@ class SubmissionServiceSpec extends TestFixture {
     "return a RuntimeException" when {
 
       "envelopeSummary fails" in {
-        when(mockPdfService.generatePdf(any())).thenReturn(Future.successful(pdfBytes))
+        when(mockPdfService.generatePdf(any())(any())).thenReturn(Future.successful(pdfBytes))
 
         when(mockFileUploadService.createEnvelope()(any())).thenReturn(Future.successful("1"))
 
@@ -65,7 +65,7 @@ class SubmissionServiceSpec extends TestFixture {
       }
 
       "createEnvelope fails" in {
-        when(mockPdfService.generatePdf(any())).thenReturn(Future.successful(pdfBytes))
+        when(mockPdfService.generatePdf(any())(any())).thenReturn(Future.successful(pdfBytes))
 
         when(mockFileUploadService.createEnvelope()(any())).thenReturn(Future.failed(new RuntimeException))
 
@@ -81,7 +81,7 @@ class SubmissionServiceSpec extends TestFixture {
       }
 
       "generatePdf fails" in {
-        when(mockPdfService.generatePdf(any())).thenReturn(Future.failed(new RuntimeException))
+        when(mockPdfService.generatePdf(any())(any())).thenReturn(Future.failed(new RuntimeException))
 
         when(mockFileUploadService.createEnvelope()(any())).thenReturn(Future.successful("1"))
 
@@ -97,7 +97,7 @@ class SubmissionServiceSpec extends TestFixture {
       }
 
       "envelopeSummary is not OPEN" in {
-        when(mockPdfService.generatePdf(any())).thenReturn(Future.successful(pdfBytes))
+        when(mockPdfService.generatePdf(any())(any())).thenReturn(Future.successful(pdfBytes))
 
         when(mockFileUploadService.createEnvelope()(any())).thenReturn(Future.successful("1"))
 
@@ -119,7 +119,7 @@ class SubmissionServiceSpec extends TestFixture {
     "return an SubmissionResponse" when {
 
       "given valid inputs" in {
-        when(mockPdfService.generatePdf(any())).thenReturn(Future.successful(pdfBytes))
+        when(mockPdfService.generatePdf(any())(any())).thenReturn(Future.successful(pdfBytes))
 
         when(mockFileUploadService.createEnvelope()(any())).thenReturn(Future.successful("1"))
 


### PR DESCRIPTION
# DDCE-1860

- Header is being passed implicitly where the request is being made using `DefaultHttpClient`
- Header is being passed explicitly where the request is being made using `WSClient`

- [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
- [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
- [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
- [x]  I've squashed my commits - including the JIRA issue number in the commit message
- [ ]  I've run a dependency check to ensure all dependencies are up to date